### PR TITLE
Configurable run_time

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -21,6 +21,12 @@
                 "type": "string",
                 "default": "MySecretPassword",
                 "required": true
+            },
+            "run_time": {
+                "title": "Run time",
+                "type": "integer",
+                "default": 50,
+                "required": true
             }
         }
     }

--- a/platform.js
+++ b/platform.js
@@ -14,6 +14,7 @@ class PlatformOrbit {
 
       this.email = config["email"];
       this.password = config["password"];
+      this.run_time = config["run_time"]
       this.accessories = [];
 
       this.log('Starting OrbitPlatform using homebridge API', api.version);
@@ -302,7 +303,7 @@ class PlatformOrbit {
     // Prepare message for API
     let station = valveService.getCharacteristic(Characteristic.ServiceLabelIndex).value;
     //let run_time = valveService.getCharacteristic(Characteristic.SetDuration).value / 60;
-    let run_time = 51
+    let run_time = this.run_time
 
     if (value == Characteristic.Active.ACTIVE) {
       // Turn on the valve

--- a/platform.js
+++ b/platform.js
@@ -301,7 +301,8 @@ class PlatformOrbit {
 
     // Prepare message for API
     let station = valveService.getCharacteristic(Characteristic.ServiceLabelIndex).value;
-    let run_time = valveService.getCharacteristic(Characteristic.SetDuration).value / 60;
+    //let run_time = valveService.getCharacteristic(Characteristic.SetDuration).value / 60;
+    let run_time = 51
 
     if (value == Characteristic.Active.ACTIVE) {
       // Turn on the valve


### PR DESCRIPTION
Workaround for issue #26 

Since this bug is preventing the user from defining a run time, the default run time can now be configured in homebridge, bypassing the iOS setting.

I'm aware that not ideal, but it's only temporary and, honestly, we pretty much always the same run time anyway.